### PR TITLE
Digest login key before hashing

### DIFF
--- a/src/handlers/LoginHandler.js
+++ b/src/handlers/LoginHandler.js
@@ -197,8 +197,10 @@ export default class LoginHandler {
         let address = socket.handshake.address
         let userAgent = socket.request.headers['user-agent']
 
+        let digest = crypto.createHash('sha256').update(`${user.username}${randomKey}${address}${userAgent}`).digest('hex')
+
         // Create hash of login key and user data
-        let hash = await bcrypt.hash(`${user.username}${randomKey}${address}${userAgent}`, this.config.crypto.rounds)
+        let hash = await bcrypt.hash(digest, this.config.crypto.rounds)
 
         // JWT to be stored on database
         return jwt.sign({


### PR DESCRIPTION
Bcrypt has a maximum input length of 72. Characters after the 72nd byte are truncated. That means that in most cases, the address & userAgent weren't actually being added to the resulting login hash, and not all 64 bytes of the random key were being added (depending on the username), which is potentially a security issue.

To fix this we can just use a weaker hashing algorithm to digest the login key such as SHA256, and then use bcrypt afterwards.

I should also mention that bcrypt here isn't really necessary, and actually could cause slowness, but it's not that big of a deal.