### PR TITLE
Add Agent/Tour Guide paychecks

### DIFF
--- a/src/database/collections/PostcardCollection.js
+++ b/src/database/collections/PostcardCollection.js
@@ -7,12 +7,13 @@ export default class PostcardCollection extends Collection {
         super(user, models, 'postcards', 'id')
     }
 
-    async add(senderId, postcardId, details = null) {
+    async add(senderId, postcardId, details = null, date = new Date()) {
         try {
             const model = await this.model.create({
                 userId: this.user.id,
                 senderId: senderId,
                 postcardId: postcardId,
+                sendDate: date,
                 details: details
             })
 

--- a/src/database/models/Users.js
+++ b/src/database/models/Users.js
@@ -43,6 +43,11 @@ export default class Users extends BaseModel {
                     allowNull: false,
                     defaultValue: sequelize.literal('CURRENT_TIMESTAMP')
                 },
+                lastLogin: {
+                    type: Sequelize.DATE,
+                    allowNull: true,
+                    defaultValue: null
+                },
                 coins: {
                     type: DataTypes.INTEGER(11),
                     allowNull: false,

--- a/src/objects/user/GameUserMixin.js
+++ b/src/objects/user/GameUserMixin.js
@@ -137,8 +137,8 @@ const GameUserMixin = {
         }
     },
 
-    async addSystemMail(postcardId, details = null) {
-        const postcard = await this.postcards.add(null, postcardId, details)
+    async addSystemMail(postcardId, details = null, date = new Date()) {
+        const postcard = await this.postcards.add(null, postcardId, details, date)
 
         if (postcard) this.send('receive_mail', postcard)
 
@@ -174,6 +174,39 @@ const GameUserMixin = {
 
             this.walkingPet.walking = false
             this.walkingPet = null
+        }
+    },
+
+    sendPaychecks() {
+        if (!this.lastLogin) return
+
+        const today = new Date()
+        let nextDate = this.lastLogin
+
+        let payment = 0
+
+        while (nextDate <= today) {
+            nextDate = new Date(nextDate.getFullYear(), nextDate.getMonth() + 1, 1)
+
+            if (nextDate > today) {
+                break
+            }
+
+            // Secret Agent
+            if (this.inventory.includes(800)) {
+                payment += 250
+                this.addSystemMail(171, null, nextDate)
+            }
+
+            // Tour Guide
+            if (this.inventory.includes(428)) {
+                payment += 250
+                this.addSystemMail(172, null, nextDate)
+            }
+        }
+
+        if (payment > 0) {
+            this.updateCoins(payment)
         }
     },
 
@@ -279,6 +312,7 @@ const GameUserMixin = {
             'id',
             'username',
             'joinTime',
+            'lastLogin',
             'head',
             'face',
             'neck',

--- a/src/plugin/plugins/game/Join.js
+++ b/src/plugin/plugins/game/Join.js
@@ -20,6 +20,8 @@ export default class Join extends GamePlugin {
     // Events
 
     async joinServer(args, user) {
+        user.sendPaychecks()
+
         user.send('load_player', {
             user: user,
             rank: user.rank,
@@ -46,6 +48,8 @@ export default class Join extends GamePlugin {
         user.joinRoom(spawn)
 
         user.joinedServer = true
+
+        user.update({ lastLogin: new Date() })
 
         await this.handler.updateWorldPopulation()
     }

--- a/yukon.sql
+++ b/yukon.sql
@@ -107,6 +107,7 @@ CREATE TABLE `users` (
   `rank` tinyint(1) NOT NULL DEFAULT 1,
   `permaBan` tinyint(1) NOT NULL DEFAULT 0,
   `joinTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  `lastLogin` timestamp NULL DEFAULT NULL,
   `coins` int(11) NOT NULL DEFAULT 500,
   `head` int(11) NOT NULL DEFAULT 0,
   `face` int(11) NOT NULL DEFAULT 0,


### PR DESCRIPTION
This adds the ability for monthly paychecks to be sent out for users who are Secret Agents and Tour Guides.

## How it works
The server checks if paychecks are able to be sent out. For every month that a user did not login in comparison to the last login, it checks if a user is eligible for any paychecks. If a user is a secret agent (owns inventory item 800), then it adds 250 coins and adds the system mail (171) at the current month in the loop. This same check is done for tour guides (if user owns item 428, add 250 coins and add mail 172).

## Changes
A new database column has been added to users: `lastLogin`. This is updated with the current timestamp when a user joins a server. This is updated *after* the paycheck checks are done, so that the calculations are accurate.
`yukon.sql` has been updated to account for this change, but if you'd like to add it without having to delete and remake your entire DB, then the following migration can be ran:
```sql
ALTER TABLE users
ADD COLUMN lastLogin timestamp NULL DEFAULT NULL AFTER joinTime;
```

the `Postcards` DB model has been updated to allow for a custom timestamp to be inserted, rather than just defaulting to the current timestamp (which it still does). Only system mail takes advantage of this.

## Note
The client or server may need to be updated to have times be in Penguin (Pacific) Standard Time, but I'm not too good with that since that's kinda tricky to test.