### PR TITLE
Fix potential prototype pollution for database.

### DIFF
--- a/src/database/Collection.js
+++ b/src/database/Collection.js
@@ -1,3 +1,4 @@
+const DANGEROUS = new Set(["__proto__", "constructor", "prototype"]);
 export default class Collection {
 
     constructor(user, models, model, indexKey) {
@@ -55,6 +56,7 @@ export default class Collection {
     }
 
     includes(key) {
+        if(DANGEROUS.has(key)) return false;
         return key in this.collection
     }
 


### PR DESCRIPTION
An attacker could pollute the prototype of sequelize and crash the server
https://github.com/wizguin/yukon-server/blob/fead5f7849e97a866e07d39213ff41b970497f4e/src/plugin/plugins/game/Pet.js#L50